### PR TITLE
Update for new required argument

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -8,10 +8,9 @@ if [ $? -ne 0 ]
 then
     echo "New version available, updating..."
     wget -N https://github.com/SlimeVR/SlimeVR-Server/releases/latest/download/slimevr.jar
-    termux-open-url https://slimevr-gui.bscotch.ca/
-    java -jar slimevr.jar
 else
     echo "Latest version installed, not updating..."
-    termux-open-url https://slimevr-gui.bscotch.ca/
-    java -jar slimevr.jar
 fi
+
+termux-open-url https://slimevr-gui.bscotch.ca/
+java -jar slimevr.jar run


### PR DESCRIPTION
The new version of SlimeVR (0.8.0) requires a new argument `run` to actually run the server, this prevents people from accidentally running the jar instead of the GUI, but this needs to be updated in this script for it to actually run on Termux.

Also merged the duplicate code in the if :3